### PR TITLE
fixes #6 toggle info text of focus/blur & refactor

### DIFF
--- a/src/components/AppItem.vue
+++ b/src/components/AppItem.vue
@@ -5,9 +5,11 @@
         {{ unit.name }}
       <button v-if="isFolder">{{ arrOpen ? '-' : '+' }}</button>
       <button 
-        v-if="comments[unit.path]"  
-        @mouseenter="noteShowing = true" 
-        @mouseleave="noteShowing = false"
+        v-if="comments[unit.path]"
+        @blur="toggleNoteShowing"
+        @focus="toggleNoteShowing"
+        @mouseenter="toggleNoteShowing"
+        @mouseleave="toggleNoteShowing"
         class="info"
       >
         info
@@ -53,6 +55,9 @@ export default {
     }
   },
   methods: {
+    toggleNoteShowing() {
+      this.noteShowing = !this.noteShowing
+    },
     toggleOpened(name) {
       this.$store.commit('toggleOpened', name)
     }


### PR DESCRIPTION
Fixes problem about navigating with tab between the `info` buttons.
Now the `info` buttons show their attached note on `focus` and hide it on `blur`, so tab navigation is fine :). And this way it's not necesary to hit a key to show it, so faster for the user also :).
I also created a method to refactor the way the change of the note visibility is handled.